### PR TITLE
Update modules debug pipe error

### DIFF
--- a/installer/modules.go
+++ b/installer/modules.go
@@ -15,7 +15,6 @@
 package installer
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -135,36 +134,6 @@ func (rl *ReadLogger) Write(p []byte) (int, error) {
 		log.Infof("Update module output: %s", line)
 	}
 	return len(p), nil
-}
-
-func (mod *ModuleInstaller) readAndLog(r io.ReadCloser, capture bool) (string, error) {
-	var output string
-	lineReader := bufio.NewReader(r)
-	defer r.Close()
-
-	for true {
-		line, err := lineReader.ReadString(byte('\n'))
-		if err != nil && err != io.EOF {
-			log.Errorf("Reading from update module yielded error: %s", err.Error())
-			return output, err
-		}
-		line = strings.TrimRight(line, "\n")
-
-		if len(line) > 0 {
-			if capture {
-				log.Debugf("Update module output: %s", line)
-				output = output + line
-			} else {
-				log.Infof("Update module output: %s", line)
-			}
-		}
-
-		if err == io.EOF {
-			break
-		}
-	}
-
-	return output, nil
 }
 
 func (mod *ModuleInstaller) payloadPath() string {
@@ -714,21 +683,13 @@ func (mod *ModuleInstaller) PrepareStoreUpdate() error {
 	log.Infof("Calling module: %s Download %s", mod.programPath, payloadPath)
 	storeUpdateCmd := exec.Command(mod.programPath, "Download", payloadPath)
 	storeUpdateCmd.Dir = mod.payloadPath()
-	stdout, err := storeUpdateCmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	stderr, err := storeUpdateCmd.StderrPipe()
-	if err != nil {
-		return err
-	}
 
-	// Log stdout and stderr in the background. Both should get their pipes
-	// closed simultaneously.
-	go mod.readAndLog(stdout, false)
-	go mod.readAndLog(stderr, false)
+	stdoutLogger := newReadLogger(false)
+	stderrLogger := newReadLogger(false)
+	storeUpdateCmd.Stdout = stdoutLogger
+	storeUpdateCmd.Stderr = stderrLogger
 
-	err = storeUpdateCmd.Start()
+	err := storeUpdateCmd.Start()
 	if err != nil {
 		log.Errorf("Module could not be executed: %s", err.Error())
 		return errors.Wrap(err, "Module could not be executed")


### PR DESCRIPTION
This is my suggested change to fix the closed pipe bug.

I tried to do it the way you suggested, using the syscall dup, but I didn't manage to get the stdout/stderr fds of the exec.Cmd struct.

However, reading in detail the go doc on both exec.Cmd.Stdout and exec.Cmd.StdoutPipe I believe that the proposed change is the way intended by the standard library. Otherwise, if we cant to use the StdoutPipe we'll need to do a wait on the reading go routines before the cmd.Wait (as done in the two days ago patch).

Here the docs:

go doc exec.Cmd.Stdout
> Stdout and Stderr specify the process's standard output and error.
If either is nil, Run connects the corresponding file descriptor to the null device (os.DevNull).
If either is an *os.File, the corresponding output from the process is connected directly to that file.
Otherwise, during the execution of the command a separate goroutine reads from the process over a pipe and delivers that data to the corresponding Writer. In this case, Wait does not complete until the goroutine reaches EOF or encounters an error.
If Stdout and Stderr are the same writer, and have a type that can be compared with ==, at most one goroutine at a time will call Write.

go doc exec.Cmd.StdoutPipe
> func (c *Cmd) StdoutPipe() (io.ReadCloser, error)
StdoutPipe returns a pipe that will be connected to the command's standard output when the command starts.
Wait will close the pipe after seeing the command exit, so most callers need not close the pipe themselves; however, an implication is that it is incorrect to call Wait before all reads from the pipe have completed. For the same reason, it is incorrect to call Run when using StdoutPipe. See the example for idiomatic usage.

The tricky thing is that now if the race condition is still there we cannot tell because there will not be logging of the error.

Anyway, what do you think?