### PR TITLE
Update Modules: remove jq dependency

### DIFF
--- a/support/modules-artifact-gen/docker-artifact-gen
+++ b/support/modules-artifact-gen/docker-artifact-gen
@@ -20,6 +20,11 @@ Usage: $0 [options] IMAGE [IMAGES...]
 EOF
 }
 
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
 check_dependency() {
   hash "$1" || exit 1
 }
@@ -37,14 +42,23 @@ IMAGES=""
 while (( "$#" )); do
   case "$1" in
     --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
       device_type=$2
       shift 2
       ;;
     --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
       artifact_name=$2
       shift 2
       ;;
     --output-path | -o)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
       output_path=$2
       shift 2
       ;;
@@ -54,8 +68,7 @@ while (( "$#" )); do
       ;;
     -*)
       echo "Error: unsupported option $1"
-      show_help
-      exit 1
+      show_help_and_exit_error
       ;;
     *)
       IMAGES="$IMAGES $1"
@@ -66,20 +79,17 @@ done
 
 if [ -z "${artifact_name}" ]; then
   echo "Artifact name not specified. Aborting."
-  show_help
-  exit 1
+  show_help_and_exit_error
 fi
 
 if [ -z "${device_type}" ]; then
   echo "Device type not specified. Aborting."
-  show_help
-  exit 1
+  show_help_and_exit_error
 fi
 
 if [ -z "${IMAGES}" ]; then
   echo "At least one Docker image must be specified. Aborting."
-  show_help
-  exit 1
+  show_help_and_exit_error
 fi
 
 HASHES=""

--- a/support/modules-artifact-gen/file-install-artifact-gen
+++ b/support/modules-artifact-gen/file-install-artifact-gen
@@ -21,6 +21,11 @@ Usage: $0 [options] file-tree
 EOF
 }
 
+show_help_and_exit_error() {
+  show_help
+  exit 1
+}
+
 check_dependency() {
   hash "$1" || exit 1
 }
@@ -38,18 +43,30 @@ file_tree=""
 while (( "$#" )); do
   case "$1" in
     --device-type | -t)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
       device_type=$2
       shift 2
       ;;
     --artifact-name | -n)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
       artifact_name=$2
       shift 2
       ;;
     --dest-dir | -d)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
       dest_dir=$2
       shift 2
       ;;
     --output-path | -o)
+      if [ -z "$2" ]; then
+        show_help_and_exit_error
+      fi
       output_path=$2
       shift 2
       ;;
@@ -59,14 +76,12 @@ while (( "$#" )); do
       ;;
     -*)
       echo "Error: unsupported option $1"
-      show_help
-      exit 1
+      show_help_and_exit_error
       ;;
     *)
       if [ -n "$file_tree" ]; then
         echo "File tree already specified. Unrecognized argument \"$1\""
-        show_help
-        exit 1
+        show_help_and_exit_error
       fi
       file_tree="$1"
       shift
@@ -76,26 +91,22 @@ done
 
 if [ -z "${artifact_name}" ]; then
   echo "Artifact name not specified. Aborting."
-  show_help
-  exit 1
+  show_help_and_exit_error
 fi
 
 if [ -z "${device_type}" ]; then
   echo "Device type not specified. Aborting."
-  show_help
-  exit 1
+  show_help_and_exit_error
 fi
 
 if [ -z "${dest_dir}" ]; then
   echo "Destination dir not specified. Aborting."
-  show_help
-  exit 1
+  show_help_and_exit_error
 fi
 
 if [ -z "${file_tree}" ]; then
   echo "File tree not specified. Aborting."
-  show_help
-  exit 1
+  show_help_and_exit_error
 fi
 
 # Check dest-dir is an absolute path

--- a/support/modules-artifact-gen/file-install-artifact-gen
+++ b/support/modules-artifact-gen/file-install-artifact-gen
@@ -26,14 +26,13 @@ check_dependency() {
 }
 
 check_dependency mender-artifact
-check_dependency jq
 
 device_type=""
 artifact_name=""
 dest_dir=""
 output_path="file-install-artifact.mender"
-meta_data_file="meta-data.json"
 update_files_tar="update.tar"
+dest_dir_file="dest_dir"
 file_tree=""
 
 while (( "$#" )); do
@@ -125,8 +124,8 @@ else
 fi
 
 
-# Create meta-data
-eval "jq -n --argjson d '\"$dest_dir\"' '{\"dest-dir\": \$d}'" > $meta_data_file
+# Create dest_dir file in plain text
+echo "$dest_dir" > $dest_dir_file
 
 mender-artifact write module-image \
   -T file-install \
@@ -134,10 +133,10 @@ mender-artifact write module-image \
   -o $output_path \
   -n $artifact_name \
   -f $update_files_tar \
-  -m $meta_data_file
+  -f $dest_dir_file
 
-rm $meta_data_file
 rm $update_files_tar
+rm $dest_dir_file
 
 echo "Artifact $output_path generated successfully:"
 mender-artifact read $output_path

--- a/support/modules/file-install
+++ b/support/modules/file-install
@@ -7,6 +7,7 @@ FILES="$2"
 
 prev_files_tar="$FILES"/tmp/prev_files.tar
 update_files_tar="$FILES"/files/update.tar
+dest_dir_file="$FILES"/files/dest_dir
 
 case "$STATE" in
 
@@ -19,7 +20,7 @@ case "$STATE" in
     ;;
 
     ArtifactInstall)
-        dest_dir=$(jq -r ".[]" "$FILES"/header/meta-data)
+        dest_dir=$(cat $dest_dir_file)
         [[ -d $dest_dir ]] || install -d $dest_dir
         echo tar -cf ${prev_files_tar} -C ${dest_dir} .
         tar -cf ${prev_files_tar} -C ${dest_dir} .
@@ -30,7 +31,7 @@ case "$STATE" in
         ;;
 
     ArtifactRollback)
-        dest_dir=$(jq -r ".[]" "$FILES"/header/meta-data)
+        dest_dir=$(cat $dest_dir_file)
         [[ -f $prev_files_tar ]] || exit 1
         [[ -n "$dest_dir" ]] || exit 1
         rm -rf ${dest_dir}


### PR DESCRIPTION
Remove jq dependency for file-install Update Module

Instead of meta-data, use plain text in a file named 'dest_dir'
