### PR TITLE
Fix missing coverage from test cases running in sub processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,14 @@ htmlcover: coverage
 
 coverage:
 	rm -f coverage.txt
-	$(GO) test -coverprofile=coverage.txt ./...
+	$(GO) test -coverprofile=coverage-tmp.txt ./...
+	if [ -f coverage-missing-subtests.txt ]; then \
+		echo 'mode: set' > coverage.txt; \
+		cat coverage-tmp.txt coverage-missing-subtests.txt | grep -v 'mode: set' >> coverage.txt; \
+	else \
+		mv coverage-tmp.txt coverage.txt; \
+	fi
+	rm -f coverage-tmp.txt coverage-missing-subtests.txt
 
 .PHONY: build clean get-tools test check \
 	cover htmlcover coverage


### PR DESCRIPTION
Each sub process will save the coverage info in the same file, overriding
the previous contents. Furthermore, the "main" test process will also
override the contents with its own coverage at the end

Create an independent file where to append cover results of each sub
process modify the Makefile accordignly to manually merge the cover
results into a final single file

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>